### PR TITLE
feat: enable pagination for followed races table.

### DIFF
--- a/src/pages/race.js
+++ b/src/pages/race.js
@@ -133,13 +133,15 @@ import { Table } from 'antd';
     }
     // 筛选发生变化时清空已经选择的内容
     const onChange = (pagination, filters, sorter, extra) => {
-      props.onSelect([])
-      setSelectedRowKeys([])
+      if (extra.action === 'filter') {
+        props.onSelect([])
+        setSelectedRowKeys([])
+      } 
     }
     return(
       <div>
       <Table rowSelection={props.onSelect?rowSelection:null} columns={columns}
-      dataSource={allRaceList} onChange={onChange} pagination={false} scroll={{y:dynamicTableHeight}}/>
+      dataSource={allRaceList} onChange={onChange} scroll={{y:dynamicTableHeight}}/>
       </div>
       )
   }


### PR DESCRIPTION
为什么把分页关了啊，这样每次选择关注赛事的要渲染好多东西，很卡啊。

Hey,
I notice you disable pagination for _followed races table_ for some certain purposes. I'm not sure why it was so because browser spends a lot of time rendering this table.