### PR TITLE
chore: do not config public path when develop

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -9,12 +9,15 @@ module.exports = override(
     libraryName:'antd-mobile',
     style:true
   }),
-  (config)=>{
-    const paths = require('react-scripts/config/paths');
-
+  (config) => {
+    // 在开发环境不修改 publicUrl
+    if (process.env.NODE_ENV === "development") {
+      return config;
+    }
+    const paths = require("react-scripts/config/paths");
     // 修改public path to github cdn
-    paths.publicUrl = 'https://cdn.jsdelivr.net/gh/wrrwrr111/pretty-derby/build/'
-    config.output.publicPath = 'https://cdn.jsdelivr.net/gh/wrrwrr111/pretty-derby/build/'
-    return config
+    paths.publicUrl = "https://cdn.jsdelivr.net/gh/wrrwrr111/pretty-derby/build/";
+    config.output.publicPath = "https://cdn.jsdelivr.net/gh/wrrwrr111/pretty-derby/build/";
+    return config;
   }
 )


### PR DESCRIPTION
在通过 `react-app-rewired start`或者 `create-react-app start` 启动开发环境时，会自动设置环境变量 `NODE_ENV` 为 `development`。

这项 PR 阻止了在开发环境下将 `publicUrl` 设置成 CDN 地址，避免启动开发环境时载入静态文件的 403 错误。

<img width="872" alt="Screen Shot 2021-04-05 at 15 13 34" src="https://user-images.githubusercontent.com/6264033/113548079-81c21700-9621-11eb-9e32-a535b1c27fa7.png">


Refs: https://create-react-app.dev/docs/adding-custom-environment-variables/